### PR TITLE
モジュール名をAudirvanaに変更

### DIFF
--- a/lib/Cask/Audirvana.pm
+++ b/lib/Cask/Audirvana.pm
@@ -1,4 +1,4 @@
-package Cask::AudirvanaPlus;
+package Cask::Audirvana;
 
 use strict;
 use warnings;
@@ -26,7 +26,7 @@ sub url {
     return undef;
   }
 
-  return "https://audirvana.com/delivery/AudirvanaPlus_${version}.dmg";
+  return "https://audirvana.com/delivery/Audirvana_${version}.dmg";
 }
 
 1;


### PR DESCRIPTION
アプリケーション名がAudirvana PlusからAudirvanaになったため